### PR TITLE
adapter: Fix option parsing

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -245,7 +245,7 @@ class NetworkAdapter:
                 for key in options.keys():
                     if key == 'name':
                         self.setName(options[key])
-                    if key == 'addrFam':
+                    elif key == 'addrFam':
                         self.setAddrFam(options[key])
                     elif key == 'source':
                         self.setAddressSource(options[key])


### PR DESCRIPTION
name ended up as a unknown option due to not being part of the if/elif block.

Signed-off-by: Julian Scheel julian@jusst.de
